### PR TITLE
DE-2855: Add scopes option support

### DIFF
--- a/driver/connection.go
+++ b/driver/connection.go
@@ -32,7 +32,7 @@ func (connection *bigQueryConnection) Ping(ctx context.Context) error {
 
 	dataset := connection.GetDataset()
 	if dataset == nil {
-		return fmt.Errorf("faild to ping using '%s' dataset", connection.config.dataSet)
+		return fmt.Errorf("failed to ping using '%s' dataset", connection.config.dataSet)
 	}
 
 	_, err := dataset.Metadata(ctx)


### PR DESCRIPTION
# Background
The team is using the `gorm` driver to connect to BigQuery in our Go pipelines, however, we found the need to authenticate not only by the `GOOGLE_APPLICATION_CREDENTIALS` environment variable but also by including [OAuth2 scopes](https://developers.google.com/identity/protocols/oauth2/scopes).

# Summary

- Add support to the driver in order to authenticate using scopes.
  - Refactor the existing method that parses the URI to be parsed by using the `net/url` and `path` libraries.
  - Use the [WithScopes() option ](https://pkg.go.dev/google.golang.org/api/option#WithScopes) to create the [bigquery client.](https://pkg.go.dev/cloud.google.com/go/bigquery#NewClient)
  - The scopes will be included as optional in the connection string as follows: `bigquery://project_id/dataset?scopes=scope1,scope2,scope3`
- No breaking changes have been introduced:
  -  The `configFromURI()` function has been refactored to meet the same behavior as before.
  - The scopes in the URI string can be added as optional without affecting the current behavior if the query parameter is not present.

## Notes
The behavior of both original and new `configFromURI()` functions with the different use cases that I found can be checked in this [simple playground.](https://go.dev/play/p/yeqeRJQ7HHU)